### PR TITLE
Support flags to armor binary for inclusion paths and macros dependencies for processing headers

### DIFF
--- a/include/header_processor.hpp
+++ b/include/header_processor.hpp
@@ -10,7 +10,9 @@ void processHeaderPair(const std::string& projectRoot1,
                        const std::string& file1,
                        const std::string& projectRoot2,
                        const std::string& file2,
-                       const std::string& reportFormat);
+                       const std::string& reportFormat,
+                       const std::vector<std::string>& IncludePaths,
+                       const std::vector<std::string>& macroFlags);
 std::vector<std::string> getClangFlags();
 
 #endif

--- a/include/options_handler.hpp
+++ b/include/options_handler.hpp
@@ -5,6 +5,6 @@
 
 #include <string>
 
-bool handleCommandLineOptions(int argc, const char **argv);
+bool runArmorTool(int argc, const char **argv);
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "options_handler.hpp"
 
 int main(int argc, const char **argv) {
-    if (!handleCommandLineOptions(argc, argv)) {
+    if (!runArmorTool(argc, argv)) {
         return 1;
     }
     return 0;


### PR DESCRIPTION
### **Description**
- **Added new flags to ARMOR binary:**
  - `-I` for passing inclusion paths.
  - `-m` for passing macro definitions.
- These flags enable deeper compatibility analysis by providing additional context for header processing and AST generation.

---

### **Implementation Details**
- Updated **`options_handler.cpp`** to support:
  - `-I,--include-paths` for inclusion paths.
  - `-m,--macro-flags` for macro definitions.
- Paths passed via `-I` should be **relative to the given `projectroot`**. The tool automation handles prefixing the project root to these paths.
- Updated **`header_processor.cpp`**:
  - Pass all flags (inclusion paths and macros) together for AST generation.
- Updated arguments to **`processHeaderPair`** to include inclusion paths and macros.

---

### **Example Usage**
```bash
build/armor \
    /tmp/ravali1/coretech-config-vendor \
    /tmp/ravali2/coretech-config-vendor1 \
    diag/include/diag.h \
    -Idiag/include \
    -Idepes/vendor/qcom/proprietary/common/inc \
    --log-level INFO \
    -m "-DLIB_LOAD_PATH=\"/vendor/lib64\" -DNDEBUG -DANDROID_STRICT \
        -DDO_NOT_CHECK_MANUAL_BINDER_INTERFACES -D__ANDROID_VENDOR__"
```