### PR TITLE
Add placeholder for unresolved data types in API nodes

### DIFF
--- a/include/diff_utils.hpp
+++ b/include/diff_utils.hpp
@@ -5,6 +5,8 @@
 #include <string>
 #include "node.hpp"
 
+extern std::string DATA_TYPE_PLACE_HOLDER;
+
 extern std::string ADDED;
 extern std::string REMOVED;
 extern std::string MODIFIED;

--- a/src/diff_utils.cpp
+++ b/src/diff_utils.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include "diff_utils.hpp"
 
+std::string DATA_TYPE_PLACE_HOLDER = "(un-resolved Type)";
+
 std::string ADDED = "added";
 std::string REMOVED = "removed";
 std::string MODIFIED = "modified";

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -25,7 +25,9 @@ nlohmann::json APINode::diff(const std::shared_ptr<const APINode>& other) const 
     };
 
     // Compare fields
-    compare(DATA_TYPE, dataType, other->dataType, std::string{});
+    if(dataType != DATA_TYPE_PLACE_HOLDER && other->dataType != DATA_TYPE_PLACE_HOLDER){
+        compare(DATA_TYPE, dataType, other->dataType, std::string{});
+    }
     compare(
         STORAGE_QUALIFIER, 
         storage, 


### PR DESCRIPTION
Handle incomplete or invalid types by introducing a DATA_TYPE_PLACE_HOLDER constant that prevents comparison errors during diff operations. Skip type comparison when placeholders are detected and use the placeholder for function return types and declarations that cannot be properly resolved.