### PR TITLE
fix: Rename armor_config.yaml to config.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,7 @@ runs:
       run: |
         set -euo pipefail
         bash "${{ github.action_path }}/action_script/parse_headers.sh" \
-          "$GITHUB_WORKSPACE/public_headers/armor_config.yaml" \
+          "$GITHUB_WORKSPACE/public_headers/config.yml" \
           "${{ inputs.branch-name }}" \
           "$GITHUB_WORKSPACE/base" \
           "$GITHUB_WORKSPACE/head" \


### PR DESCRIPTION
Updated the configuration file from `armor_config.yaml` to `config.yml` for consistency. Adjusted references in the action to use the new file name.