### PR TITLE
v0.6.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 project(armor)
-set(TOOL_VERSION "0.6.8")
+set(TOOL_VERSION "0.6.9")
 set(TOOL_DOCS_URL "https://github.com/qualcomm/armor/blob/main/README.md")
 
 set(CMAKE_CXX_STANDARD 17)

--- a/src/beta/src/tree_builder.cpp
+++ b/src/beta/src/tree_builder.cpp
@@ -494,6 +494,7 @@ bool beta::TreeBuilder::BuildCXXRecordNode(clang::CXXRecordDecl* Decl) {
 
     cxxRecordNode->access = getAccessSpecifier(Decl->getAccess());
     cxxRecordNode->isFinal = Decl->isEffectivelyFinal();
+    cxxRecordNode->access = getAccessSpecifier(Decl->getAccess());
 
     if( Decl->isStruct() ){
         cxxRecordNode->kind = NodeKind::Struct;
@@ -599,6 +600,7 @@ bool beta::TreeBuilder::BuildEnumNode(clang::EnumDecl* Decl){
 
     const clang::QualType enumType = Decl->getIntegerType();
     std::string enumaratorDataType = enumType.getAsString();
+    enumNode->access = getAccessSpecifier(Decl->getAccess());
 
     for (const auto* EnumConstDecl : Decl->enumerators()) {
         if(!Decl->isThisDeclarationADefinition()) continue;
@@ -750,6 +752,7 @@ bool beta::TreeBuilder::BuildTypedefDecl(clang::TypedefDecl *Decl) {
     typeDefNode->caonicalType = canonicalType;
     typeDefNode->USR = USR;
     typeDefNode->NSR = generateNSRForDecl(Decl);
+    typeDefNode->access = getAccessSpecifier(Decl->getAccess());
     context->usrNodeMap.insert_or_assign(std::move(USR), typeDefNode);
 
     armor::debug() << "VisitTypeDefDecl V2: " << typeDefNode->qualifiedName << "\n";
@@ -872,6 +875,7 @@ void beta::TreeBuilder::BuildFriendCxxRecordDecl(const clang::CXXRecordDecl *Dec
     std::shared_ptr<APINode> friendCxxRecordNode = (it != context->usrNodeMap.end()) ? it->second : std::make_shared<APINode>();
     friendCxxRecordNode->NSR = NSR;
     friendCxxRecordNode->USR = USR;
+    friendCxxRecordNode->access = getAccessSpecifier(Decl->getAccess());
 
     const clang::QualType Type = FriendDecl->getFriendType()->getType();
     auto [dataType, canonicalType] = getTypesWithAndWithoutTypeResolution(Type, Decl->getASTContext());

--- a/src/tests/beta/functional/access_spec_decl_changes/__init__.py
+++ b/src/tests/beta/functional/access_spec_decl_changes/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/beta/functional/access_spec_decl_changes/expected_output.json
+++ b/src/tests/beta/functional/access_spec_decl_changes/expected_output.json
@@ -1,0 +1,569 @@
+{
+    "astDiff": [
+        {
+            "children": [
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Device::PowerLevel",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Device::PowerLevel",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Enum",
+                    "qualifiedName": "mylib::Device::PowerLevel",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Device::State",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Device::State",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Enum",
+                    "qualifiedName": "mylib::Device::State",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Device::ErrorCode",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Device::ErrorCode",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Enum",
+                    "qualifiedName": "mylib::Device::ErrorCode",
+                    "tag": "modified"
+                }
+            ],
+            "nodeType": "Class",
+            "qualifiedName": "mylib::Device",
+            "tag": "modified"
+        },
+        {
+            "children": [
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "mylib::Processor::TaskId",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "mylib::Processor::TaskId",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Typedef",
+                    "qualifiedName": "mylib::Processor::TaskId",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "mylib::Processor::ClockFreq",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "mylib::Processor::ClockFreq",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Typedef",
+                    "qualifiedName": "mylib::Processor::ClockFreq",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "mylib::Processor::CoreMask",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "mylib::Processor::CoreMask",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Typedef",
+                    "qualifiedName": "mylib::Processor::CoreMask",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "mylib::Processor::CycleCount",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "mylib::Processor::CycleCount",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Typedef",
+                    "qualifiedName": "mylib::Processor::CycleCount",
+                    "tag": "modified"
+                }
+            ],
+            "nodeType": "Class",
+            "qualifiedName": "mylib::Processor",
+            "tag": "modified"
+        },
+        {
+            "children": [
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "mylib::Controller::HandleId",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "mylib::Controller::HandleId",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Typedef",
+                    "qualifiedName": "mylib::Controller::HandleId",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Controller::Mode",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Controller::Mode",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Enum",
+                    "qualifiedName": "mylib::Controller::Mode",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "mylib::Controller::SampleRate",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "mylib::Controller::SampleRate",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Typedef",
+                    "qualifiedName": "mylib::Controller::SampleRate",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Controller::Status",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Controller::Status",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Enum",
+                    "qualifiedName": "mylib::Controller::Status",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "mylib::Controller::RegValue",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "mylib::Controller::RegValue",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Typedef",
+                    "qualifiedName": "mylib::Controller::RegValue",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Controller::Priority",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Controller::Priority",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Enum",
+                    "qualifiedName": "mylib::Controller::Priority",
+                    "tag": "modified"
+                }
+            ],
+            "nodeType": "Class",
+            "qualifiedName": "mylib::Controller",
+            "tag": "modified"
+        },
+        {
+            "children": [
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Packet::Type",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Packet::Type",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Enum",
+                    "qualifiedName": "mylib::Packet::Type",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Packet::Encoding",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Packet::Encoding",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Enum",
+                    "qualifiedName": "mylib::Packet::Encoding",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Packet::Compression",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Enum",
+                            "qualifiedName": "mylib::Packet::Compression",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Enum",
+                    "qualifiedName": "mylib::Packet::Compression",
+                    "tag": "modified"
+                }
+            ],
+            "nodeType": "Struct",
+            "qualifiedName": "mylib::Packet",
+            "tag": "modified"
+        },
+        {
+            "children": [
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Function",
+                            "qualifiedName": "mylib::Service::start",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Function",
+                            "qualifiedName": "mylib::Service::start",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Function",
+                    "qualifiedName": "mylib::Service::start",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Function",
+                            "qualifiedName": "mylib::Service::getStatus",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Function",
+                            "qualifiedName": "mylib::Service::getStatus",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Function",
+                    "qualifiedName": "mylib::Service::getStatus",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Function",
+                            "qualifiedName": "mylib::Service::reset",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Function",
+                            "qualifiedName": "mylib::Service::reset",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Function",
+                    "qualifiedName": "mylib::Service::reset",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Function",
+                            "qualifiedName": "mylib::Service::shutdown",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Function",
+                            "qualifiedName": "mylib::Service::shutdown",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Function",
+                    "qualifiedName": "mylib::Service::shutdown",
+                    "tag": "modified"
+                }
+            ],
+            "nodeType": "Class",
+            "qualifiedName": "mylib::Service",
+            "tag": "modified"
+        },
+        {
+            "children": [
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Enum",
+                            "qualifiedName": "utils::Scheduler::Policy",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Enum",
+                            "qualifiedName": "utils::Scheduler::Policy",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Enum",
+                    "qualifiedName": "utils::Scheduler::Policy",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Enum",
+                            "qualifiedName": "utils::Scheduler::Clock",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Enum",
+                            "qualifiedName": "utils::Scheduler::Clock",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Enum",
+                    "qualifiedName": "utils::Scheduler::Clock",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Enum",
+                            "qualifiedName": "utils::Scheduler::QueueKind",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Enum",
+                            "qualifiedName": "utils::Scheduler::QueueKind",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Enum",
+                    "qualifiedName": "utils::Scheduler::QueueKind",
+                    "tag": "modified"
+                }
+            ],
+            "nodeType": "Class",
+            "qualifiedName": "utils::Scheduler",
+            "tag": "modified"
+        },
+        {
+            "children": [
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "utils::Allocator::RawPtr",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "utils::Allocator::RawPtr",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Typedef",
+                    "qualifiedName": "utils::Allocator::RawPtr",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "utils::Allocator::BlockSize",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "utils::Allocator::BlockSize",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Typedef",
+                    "qualifiedName": "utils::Allocator::BlockSize",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Protected",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "utils::Allocator::AlignVal",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "utils::Allocator::AlignVal",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Typedef",
+                    "qualifiedName": "utils::Allocator::AlignVal",
+                    "tag": "modified"
+                },
+                {
+                    "children": [
+                        {
+                            "AccessSpecifier": "Private",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "utils::Allocator::Offset",
+                            "tag": "removed"
+                        },
+                        {
+                            "AccessSpecifier": "Public",
+                            "nodeType": "Typedef",
+                            "qualifiedName": "utils::Allocator::Offset",
+                            "tag": "added"
+                        }
+                    ],
+                    "nodeType": "Typedef",
+                    "qualifiedName": "utils::Allocator::Offset",
+                    "tag": "modified"
+                }
+            ],
+            "nodeType": "Class",
+            "qualifiedName": "utils::Allocator",
+            "tag": "modified"
+        }
+    ],
+    "headerResolutionFailures": [],
+    "parsed_status": 2,
+    "unparsed_status": 0
+}

--- a/src/tests/beta/functional/access_spec_decl_changes/expected_output.txt
+++ b/src/tests/beta/functional/access_spec_decl_changes/expected_output.txt
@@ -1,0 +1,106 @@
+11404736249108278501
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+----------------------------------------
+252520090170005577
+// SPDX-License-Identifier: BSD-3-Clause
+----------------------------------------
+2394147551527703550
+// Class with nested enums at all three access levels
+----------------------------------------
+14456904372539435164
+// Class with nested typedefs at all three access levels
+----------------------------------------
+13665638201297397354
+// Class mixing nested enums and typedefs
+----------------------------------------
+13170528745392673094
+// Struct with nested enums (struct members are public by default)
+----------------------------------------
+17027921307080421046
+// Class with methods at all three access levels
+----------------------------------------
+6142002387527776188
+// Class with only enums — all change access
+----------------------------------------
+14141516541700967057
+// Class with only typedefs — all change access
+----------------------------------------
+15219203312359965853
+#include <string>
+----------------------------------------
+11404736249108278501
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+----------------------------------------
+252520090170005577
+// SPDX-License-Identifier: BSD-3-Clause
+----------------------------------------
+7710412217437324749
+// Access specifiers shuffled: public->protected, protected->private, private->public
+----------------------------------------
+16155094459652271739
+// Typedef access shuffled: public->private, protected->public, private->protected
+----------------------------------------
+4823867554785128073
+// Mixed: typedef public->protected, enum public->private,
+----------------------------------------
+16741957012327425661
+//        typedef protected->public, enum protected->public,
+----------------------------------------
+4658178815253221506
+//        typedef private->public, enum private->protected
+----------------------------------------
+1615380052615763745
+// Struct nested enums shuffled: public->private, protected->public, private->protected
+----------------------------------------
+4448683053636579898
+// Methods shuffled: public->private, protected->public, private->protected
+----------------------------------------
+12429960490140525018
+// Scheduler enums shuffled: public->private, protected->public, private->protected
+----------------------------------------
+17796187518562796514
+// Allocator typedefs shuffled: public->protected, protected->private, private->public
+----------------------------------------
+15219203312359965853
+#include <string>
+----------------------------------------
+
+############ CONTEXT 1 MAPS ############
+comments1
+14456904372539435164  : 1
+252520090170005577  : 1
+17027921307080421046  : 1
+13665638201297397354  : 1
+11404736249108278501  : 1
+13170528745392673094  : 1
+6142002387527776188  : 1
+14141516541700967057  : 1
+2394147551527703550  : 1
+----------------------------------------
+unhandledDecls1
+15219203312359965853  : 1
+----------------------------------------
+inactiveUnhandledDecls1
+(empty)
+----------------------------------------
+
+############ CONTEXT 2 MAPS ############
+comments2
+12429960490140525018  : 1
+1615380052615763745  : 1
+16155094459652271739  : 1
+4658178815253221506  : 1
+252520090170005577  : 1
+4823867554785128073  : 1
+16741957012327425661  : 1
+11404736249108278501  : 1
+7710412217437324749  : 1
+4448683053636579898  : 1
+17796187518562796514  : 1
+----------------------------------------
+unhandledDecls2
+15219203312359965853  : 1
+----------------------------------------
+inactiveUnhandledDecls2
+(empty)
+----------------------------------------

--- a/src/tests/beta/functional/access_spec_decl_changes/test_access_spec_decl_changes.py
+++ b/src/tests/beta/functional/access_spec_decl_changes/test_access_spec_decl_changes.py
@@ -1,0 +1,39 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+import os
+import json
+import subprocess
+from deepdiff import DeepDiff
+
+
+def test_ast_diff(binary_path, binary_args, request):
+
+    test_dir = os.path.dirname(request.fspath)
+
+    subprocess.run(
+        [binary_path] + binary_args,
+        check=True,
+        cwd=os.path.dirname(request.fspath)
+    )
+
+    with open(f'{test_dir}/expected_output.json', 'r') as f:
+        expected_json = json.load(f)
+
+    with open(f'{test_dir}/debug_output/ast_diffs/ast_diff_output_mylib.h.json', 'r') as f:
+        actual_json = json.load(f)
+
+    diff = DeepDiff(expected_json, actual_json, ignore_order=True)
+
+    assert diff == {}
+
+    # Compare text output files line by line
+    with open(f'{test_dir}/expected_output.txt', 'r') as f:
+        expected_lines = f.readlines()
+
+    with open(f'{test_dir}/output.txt', 'r') as f:
+        actual_lines = f.readlines()
+
+    for i, (expected_line, actual_line) in enumerate(zip(expected_lines, actual_lines), 1):
+        assert expected_line == actual_line, f"Line {i} differs:\nExpected: {expected_line}\nActual: {actual_line}"
+
+    assert len(expected_lines) == len(actual_lines), f"File length differs: expected {len(expected_lines)} lines, got {len(actual_lines)} lines"

--- a/src/tests/beta/functional/access_spec_decl_changes/v1/mylib.h
+++ b/src/tests/beta/functional/access_spec_decl_changes/v1/mylib.h
@@ -1,0 +1,147 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+#pragma once
+
+#include <string>
+
+namespace mylib {
+
+    // Class with nested enums at all three access levels
+    class Device {
+    public:
+        enum class PowerLevel {
+            Low,
+            Medium,
+            High
+        };
+
+    protected:
+        enum class State {
+            Idle,
+            Running,
+            Stopped
+        };
+
+    private:
+        enum class ErrorCode {
+            None,
+            Timeout,
+            Overflow
+        };
+    };
+
+    // Class with nested typedefs at all three access levels
+    class Processor {
+    public:
+        typedef int    TaskId;
+        typedef double ClockFreq;
+
+    protected:
+        typedef unsigned int CoreMask;
+
+    private:
+        typedef long long CycleCount;
+    };
+
+    // Class mixing nested enums and typedefs
+    class Controller {
+    public:
+        typedef int HandleId;
+
+        enum class Mode {
+            Manual,
+            Auto
+        };
+
+    protected:
+        typedef float SampleRate;
+
+        enum class Status {
+            OK,
+            Error
+        };
+
+    private:
+        typedef unsigned char RegValue;
+
+        enum class Priority {
+            Low,
+            High
+        };
+    };
+
+    // Struct with nested enums (struct members are public by default)
+    struct Packet {
+    public:
+        enum class Type {
+            Data,
+            Control,
+            Ack
+        };
+
+    protected:
+        enum class Encoding {
+            Raw,
+            Base64
+        };
+
+    private:
+        enum class Compression {
+            None,
+            LZ4
+        };
+    };
+
+
+    // Class with methods at all three access levels
+    class Service {
+    public:
+        void start();
+        int getStatus();
+
+    protected:
+        void reset();
+
+    private:
+        void shutdown();
+    };
+
+}
+
+namespace utils {
+
+    // Class with only enums — all change access
+    class Scheduler {
+    public:
+        enum class Policy {
+            FIFO,
+            RoundRobin
+        };
+
+    protected:
+        enum class Clock {
+            Monotonic,
+            Realtime
+        };
+
+    private:
+        enum class QueueKind {
+            Bounded,
+            Unbounded
+        };
+    };
+
+    // Class with only typedefs — all change access
+    class Allocator {
+    public:
+        typedef void*  RawPtr;
+        typedef size_t BlockSize;
+
+    protected:
+        typedef unsigned int AlignVal;
+
+    private:
+        typedef long long Offset;
+    };
+
+}

--- a/src/tests/beta/functional/access_spec_decl_changes/v2/mylib.h
+++ b/src/tests/beta/functional/access_spec_decl_changes/v2/mylib.h
@@ -1,0 +1,152 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+#pragma once
+
+#include <string>
+
+namespace mylib {
+
+    // Access specifiers shuffled: public->protected, protected->private, private->public
+    class Device {
+    protected:
+        enum class PowerLevel {
+            Low,
+            Medium,
+            High
+        };
+
+    private:
+        enum class State {
+            Idle,
+            Running,
+            Stopped
+        };
+
+    public:
+        enum class ErrorCode {
+            None,
+            Timeout,
+            Overflow
+        };
+    };
+
+    // Typedef access shuffled: public->private, protected->public, private->protected
+    class Processor {
+    private:
+        typedef int    TaskId;
+        typedef double ClockFreq;
+
+    public:
+        typedef unsigned int CoreMask;
+
+    protected:
+        typedef long long CycleCount;
+    };
+
+    // Mixed: typedef public->protected, enum public->private,
+    //        typedef protected->public, enum protected->public,
+    //        typedef private->public, enum private->protected
+    class Controller {
+    protected:
+        typedef int HandleId;
+
+    private:
+        enum class Mode {
+            Manual,
+            Auto
+        };
+
+    public:
+        typedef float SampleRate;
+
+    public:
+        enum class Status {
+            OK,
+            Error
+        };
+
+    public:
+        typedef unsigned char RegValue;
+
+    protected:
+        enum class Priority {
+            Low,
+            High
+        };
+    };
+
+    // Struct nested enums shuffled: public->private, protected->public, private->protected
+    struct Packet {
+    private:
+        enum class Type {
+            Data,
+            Control,
+            Ack
+        };
+
+    public:
+        enum class Encoding {
+            Raw,
+            Base64
+        };
+
+    protected:
+        enum class Compression {
+            None,
+            LZ4
+        };
+    };
+
+
+    // Methods shuffled: public->private, protected->public, private->protected
+    class Service {
+    private:
+        void start();
+        int getStatus();
+
+    public:
+        void reset();
+
+    protected:
+        void shutdown();
+    };
+
+}
+
+namespace utils {
+
+    // Scheduler enums shuffled: public->private, protected->public, private->protected
+    class Scheduler {
+    private:
+        enum class Policy {
+            FIFO,
+            RoundRobin
+        };
+
+    public:
+        enum class Clock {
+            Monotonic,
+            Realtime
+        };
+
+    protected:
+        enum class QueueKind {
+            Bounded,
+            Unbounded
+        };
+    };
+
+    // Allocator typedefs shuffled: public->protected, protected->private, private->public
+    class Allocator {
+    protected:
+        typedef void*  RawPtr;
+        typedef size_t BlockSize;
+
+    private:
+        typedef unsigned int AlignVal;
+
+    public:
+        typedef long long Offset;
+    };
+
+}


### PR DESCRIPTION
## Overview

This release fixes a gap in the beta analysis engine where nested declarations
(enums, typedefs, and friend class records) inside a class or struct were not
having their C++ access specifier (`public`, `protected`, `private`) recorded.
As a result, changes to a nested declaration's access level were previously
invisible to the diff engine. Version is bumped from **0.6.8 → 0.6.9**.

---

## What Changed

### 1. Access Specifier Now Captured for Nested Declarations

Previously, when the beta tree-builder visited a nested `enum`, `typedef`, or
`friend` class declaration, it did not call `getAccessSpecifier()` on that node.
This meant the `AccessSpecifier` field was absent from the AST node, so any
change to the access level of a nested type went undetected.

The fix ensures that every nested declaration type now records its access level
at parse time, making access-specifier changes a first-class detectable
difference.

**Affected declaration kinds:**

| Declaration Kind | Builder Function |
|---|---|
| Nested `enum` / `enum class` | `BuildEnumNode` |
| Nested `typedef` | `BuildTypedefDecl` |
| Nested friend CXX record | `BuildFriendCxxRecordDecl` |
| Nested class/struct (already set; reinforced) | `BuildCXXRecordNode` |

---

## Practical Example

Consider a header `mylib.h` that evolves between two versions:

**v1/mylib.h** — original layout:

```cpp
namespace mylib {

    class Device {
    public:
        enum class PowerLevel { Low, Medium, High };   // public

    protected:
        enum class State { Idle, Running, Stopped };   // protected

    private:
        enum class ErrorCode { None, Timeout, Overflow }; // private
    };

    class Processor {
    public:
        typedef int    TaskId;     // public
        typedef double ClockFreq;  // public

    protected:
        typedef unsigned int CoreMask; // protected

    private:
        typedef long long CycleCount;  // private
    };
}
```

**v2/mylib.h** — access specifiers shuffled:

```cpp
namespace mylib {

    class Device {
    protected:
        enum class PowerLevel { Low, Medium, High };   // was public  → now protected

    private:
        enum class State { Idle, Running, Stopped };   // was protected → now private

    public:
        enum class ErrorCode { None, Timeout, Overflow }; // was private → now public
    };

    class Processor {
    private:
        typedef int    TaskId;     // was public → now private
        typedef double ClockFreq;  // was public → now private

    public:
        typedef unsigned int CoreMask; // was protected → now public

    protected:
        typedef long long CycleCount;  // was private → now protected
    };
}
```

**Before this fix** — armor reported no differences for these nodes because the
`AccessSpecifier` field was never populated.

**After this fix** — armor correctly reports each access-level change. The JSON
diff output now looks like:

```json
{
  "astDiff": [
    {
      "nodeType": "Class",
      "qualifiedName": "mylib::Device",
      "tag": "modified",
      "children": [
        {
          "nodeType": "Enum",
          "qualifiedName": "mylib::Device::PowerLevel",
          "tag": "modified",
          "children": [
            {
              "AccessSpecifier": "Public",
              "nodeType": "Enum",
              "qualifiedName": "mylib::Device::PowerLevel",
              "tag": "removed"
            },
            {
              "AccessSpecifier": "Protected",
              "nodeType": "Enum",
              "qualifiedName": "mylib::Device::PowerLevel",
              "tag": "added"
            }
          ]
        },
        {
          "nodeType": "Enum",
          "qualifiedName": "mylib::Device::State",
          "tag": "modified",
          "children": [
            {
              "AccessSpecifier": "Protected",
              "nodeType": "Enum",
              "qualifiedName": "mylib::Device::State",
              "tag": "removed"
            },
            {
              "AccessSpecifier": "Private",
              "nodeType": "Enum",
              "qualifiedName": "mylib::Device::State",
              "tag": "added"
            }
          ]
        }
      ]
    }
  ]
}
```

Each modified node now carries a `"removed"` child (old access level) and an
`"added"` child (new access level), giving a precise picture of what changed.

